### PR TITLE
feat: 로그인 시 어세스 토큰 쿠키에 저장

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,8 +1,11 @@
 import axios from 'axios';
 
+const apiURL = import.meta.env.VITE_API_URL || '/api';
+
 export const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL: apiURL,
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 });

--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -11,4 +11,13 @@ export const AuthAPI = {
     const { data } = await apiClient.post<LoginResponse>('/users/login', formData);
     return data;
   },
+
+  logout: async (accessToken: string) => {
+    const { data } = await apiClient.get('/users/logout', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return data;
+  },
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,9 +5,29 @@ import image15 from '/public/image 15.png'
 import image16 from '/public/image 16.png'
 import line1 from '/public/Line 1.svg'
 import line2 from '/public/Line 2.svg'
+import { LoginRequest } from '@/types/auth';
+import { useState } from 'react';
+import { AuthAPI } from '@/api/authAPI.ts';
 
 export const Login = () => {
   const navigate = useNavigate(); // navigate 훅 초기화
+
+  const [formData, setFormData] = useState<LoginRequest>({
+    userId: '',
+    userPwd: '',
+  });
+
+  const handleLogin = async () => {
+    try {
+      const response = await AuthAPI.login(formData);
+      console.log(response);
+      navigate('/');
+
+
+    }catch(error) {
+      alert('로그인에 실패')
+    }
+  };
 
   return (
     <div className="bg-[#252836] flex justify-center items-center min-h-screen px-4">
@@ -41,6 +61,8 @@ export const Login = () => {
               type="text"
               placeholder="아이디를 입력하세요"
               className="w-full p-2 mb-2 text-sm text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={formData.userId}
+              onChange={(e) => setFormData({ ...formData, userId: e.target.value })}
             />
             <img src={line1} alt="Line1" className="w-full h-px mb-3" />
 
@@ -49,10 +71,15 @@ export const Login = () => {
               type="password"
               placeholder="비밀번호를 입력하세요"
               className="w-full p-2 mb-2 text-sm text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={formData.userPwd}
+              onChange={(e) => setFormData({ ...formData, userPwd: e.target.value })}
             />
             <img src={line2} alt="Line2" className="w-full h-px mb-3" />
 
-            <button className="bg-[#3C5BFE] w-full text-white py-2 text-sm rounded-md mt-2 hover:bg-[#2a43c7] transition">
+            <button
+              className="bg-[#3C5BFE] w-full text-white py-2 text-sm rounded-md mt-2 hover:bg-[#2a43c7] transition"
+              onClick={handleLogin}
+            >
               login
             </button>
 


### PR DESCRIPTION
📝 설명
사용자로부터 아이디와 비밀번호를 입력받아 로그인 요청을 보내고, 
로그인 성공 시 어세스토큰은 쿠키에 저장되도록 설정하였습니다.
로그인 실패 시에는 실패 알림을 표시합니다.
API 연동은 AuthAPI.login 메서드를 사용하며, apiClient를 통해 서버와 통신합니다.

✅ 완료 조건
 - [x] 사용자 입력값(userId, userPwd)을 기반으로 로그인 요청이 전송된다
 - [x] 로그인 성공 시 어세스 토큰은 쿠키에 저장됨
 - [x] 로그인 실패 시 alert로 오류 메시지가 출력된다
 - [x] 회원가입 클릭 시 /Register 페이지로 이동한다
 - [x] 이미지 및 스타일이 정상적으로 적용된다
 - [x] 서버 주소는 .env의 VITE_API_URL을 통해 주입된다