### PR TITLE
fix: 마감 투표 결과 버튼, toast 처리, 지난 투표 제거

### DIFF
--- a/src/components/vote/detail/VoteDetailModal.tsx
+++ b/src/components/vote/detail/VoteDetailModal.tsx
@@ -7,6 +7,7 @@ import VoteOptionsMenu from '../item/VoteOptionsMenu';
 import { useAuthStore } from '@/stores/authStore';
 import { useEffect, useState } from 'react';
 import ConfirmModal from '@/components/ui/confirmModal';
+import { toast } from 'sonner';
 
 export default function VoteDetailModal() {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
@@ -101,7 +102,7 @@ export default function VoteDetailModal() {
     }
     try {
       await deleteVote(selectedVote.voteId);
-      alert('투표가 성공적으로 삭제되었습니다.');
+      toast.success('투표가 성공적으로 삭제되었습니다.');
       await fetchVotes();
       handleClose();
     } catch (err) {
@@ -116,7 +117,7 @@ export default function VoteDetailModal() {
       return;
     }
     await closeVote(selectedVote.voteId);
-    alert('투표가 마감되었습니다.');
+    toast.success('투표가 마감되었습니다.');
     handleClose();
   };
 

--- a/src/components/vote/form/VoteFormModal.tsx
+++ b/src/components/vote/form/VoteFormModal.tsx
@@ -6,6 +6,7 @@ import Modal from '@/components/ui/Modal';
 import ConfirmModal from '@/components/ui/confirmModal';
 import { useVoteStore } from '@/stores/voteStore';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 export default function VoteFormModal() {
   const navigate = useNavigate();
@@ -25,8 +26,9 @@ export default function VoteFormModal() {
         setSelectedVote({
           ...voteToEdit,
           ...data,
+          participants: voteToEdit.participants,
         });
-        alert('투표가 수정되었습니다.');
+        toast.success('투표가 수정되었습니다.');
         closeVoteForm();
         navigate('/');
         return;
@@ -39,10 +41,10 @@ export default function VoteFormModal() {
       setIsConfirmOpen(true);
     } catch (error) {
       console.error('투표 생성/수정 실패:', error);
-      alert('투표 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+      toast.error('투표 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
-  
+
   const handleConfirmClose = () => {
     setIsConfirmOpen(false);
     resetRef.current();

--- a/src/components/vote/item/VoteItem.tsx
+++ b/src/components/vote/item/VoteItem.tsx
@@ -78,9 +78,8 @@ const VoteItem: React.FC<VoteItemProps> = ({ vote }) => {
   return (
     <div
       onClick={handleClick}
-      className={`relative group cursor-pointer bg-[#1F1F1F] p-4 rounded-2xl shadow-lg w-full max-w-[300px] transition-transform duration-300 hover:scale-[1.03] ${
-        isClosed ? 'pointer-events-none opacity-50' : ''
-      }`}
+      className={`relative group cursor-pointer bg-[#1F1F1F] p-4 rounded-2xl shadow-lg w-full max-w-[300px] transition-transform duration-300 hover:scale-[1.03]
+         ${isClosed ? 'opacity-50' : ''}`}
     >
       {/* 이미지 영역 */}
       <div className="relative overflow-hidden rounded-xl">
@@ -98,7 +97,7 @@ const VoteItem: React.FC<VoteItemProps> = ({ vote }) => {
                   e.stopPropagation();
                   handleOpenResult();
                 }}
-                className="px-4 py-1 bg-white text-black rounded hover:bg-secondary hover:text-black transition"
+                className="px-4 py-1 bg-white text-black rounded hover:bg-primary hover:text-black transition font-bold"
               >
                 결과 확인
               </button>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,22 +11,23 @@ import Roulette from '@/components/ui/Roulette/Roulette';
 const HomePage = () => {
   const votes = useVoteStore((s) => s.votes);
   const fetchVotes = useVoteStore((s) => s.fetchVotes);
-  // const { requireAuth } = useRequireAuth();
-  // const openVoteForm = useUIStore((s) => s.openVoteForm);
   const selectedVote = useVoteStore((s) => s.selectedVote);
 
   useEffect(() => {
-    fetchVotes(); // 서버에서 투표 목록 불러오기
+    fetchVotes();
   }, []);
 
-  // const handleOpenModal = () => {
-  //   requireAuth(openVoteForm);
-  // };
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const visibleVotes = votes.filter((vote) => {
+    const meetingTime = new Date(vote.meetingStartTime);
+    return meetingTime >= todayStart;
+  });
 
   return (
     <div className="container overflow-hidden mx-auto px-4 py-4 flex gap-6">
       <div className="flex-1 grid gap-4 overflow-y-auto h-[770px] grid-cols-[repeat(auto-fill,_minmax(300px,_1fr))]">
-        {votes
+        {visibleVotes
           .slice()
           .sort((a, b) => {
             if (a.status !== b.status) return a.status === 'closed' ? 1 : -1;


### PR DESCRIPTION
### 🚀 작업 내용
 - 마감된 투표에 참여자용 결과 확인 버튼 추가
 - 마감 투표 클릭 시 alert 대신 toast 메시지로 안내
 - 하루(오늘 0시 기준) 지난 투표는 화면에서 자동 제외되도록 필터링 처리

### 🔍 리뷰 요청 사항
- toast 메시지 정상 출력되는지 
- 당일 기준 투표 제거 로직이 정상 작동하는지

### ✅ 체크리스트
- [✔] 코드가 정상적으로 동작하는지 테스트했습니다.
- [✔] 스타일 가이드에 맞게 작성했습니다
