### PR TITLE
fix: 마감된 투표 참여자 결과 확인 시에만 api 호출 #85

### DIFF
--- a/src/components/vote/item/VoteItem.tsx
+++ b/src/components/vote/item/VoteItem.tsx
@@ -5,6 +5,7 @@ import { useRequireAuth } from '@/hooks/api/auth/useRequireAuth';
 import React, { useEffect, useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import { VoteAPI } from '@/api/voteAPI';
+import { toast } from 'sonner';
 
 interface VoteItemProps {
   vote: VoteResponse;
@@ -25,25 +26,22 @@ const VoteItem: React.FC<VoteItemProps> = ({ vote }) => {
 
   const [isParticipated, setIsParticipated] = useState(false);
 
-  useEffect(() => {
-    const checkParticipation = async () => {
-      if (isClosed && userInfo) {
-        try {
-          const list = await VoteAPI.getParticipantList(voteId);
-          const found = list.some((p) => String(p.id) === String(userInfo.userId));
-          setIsParticipated(found);
-        } catch (err) {
-          console.error('참여 여부 확인 실패:', err);
-        }
+  const handleOpenResult = async () => {
+    try {
+      const list = await VoteAPI.getParticipantList(vote.voteId);
+      const found = list.some((p) => String(p.id) === String(userInfo?.userId));
+      if (!found) {
+        toast.warning('투표에 참여한 사용자만 결과를 볼 수 있습니다');
+        return;
       }
-    };
-    checkParticipation();
-  }, [isClosed, userInfo, voteId]);
-
-  const handleOpenResult = () => {
-    setSelectedVote(vote);
-    openVoteDetail(vote);
-    fetchParticipantList(vote.voteId);
+      setIsParticipated(true);
+      await fetchParticipantList(vote.voteId);
+      setSelectedVote(vote);
+      openVoteDetail(vote);
+    } catch (err) {
+      console.error('결과 확인 실패:', err);
+      toast.error('결과 확인에 실패했습니다');
+    }
   };
 
   const handleClick = () => {


### PR DESCRIPTION
### 🚀 작업 내용
- VoteItem에서 렌더링 시점마다 참여자 리스트 API가 자동 호출되던 문제 해결

### 🔍 리뷰 요청 사항

참여자 리스트 호출 api 안 부르는지 

### ✅ 체크리스트

<!-- PR을 보내기 전에 확인해야 할 사항들을 체크해주세요. -->

- [x] 코드가 정상적으로 동작하는지 테스트했습니다.
- [x] 스타일 가이드에 맞게 작성했습니다
