### PR TITLE
feat: 모달 최신 데이터 fetch하여 상태 업데이트 (vote 변경된 경우) #92

### DIFF
--- a/src/components/vote/detail/VoteDetailModal.tsx
+++ b/src/components/vote/detail/VoteDetailModal.tsx
@@ -56,6 +56,32 @@ export default function VoteDetailModal() {
   }, [selectedVote]);
 
   useEffect(() => {
+    let isMounted = true;
+
+    const fetchLatestVote = async () => {
+      if (!selectedVote) return;
+
+      const latestVotes = useVoteStore.getState().votes;
+      const latest = latestVotes.find((v) => v.voteId === selectedVote.voteId);
+
+      if (!latest) {
+        await updateSelectedVote(selectedVote.voteId);
+      } else if (
+        latest.description !== selectedVote.description ||
+        latest.participants !== selectedVote.participants
+      ) {
+        setSelectedVote(latest); // 변경사항이 있을 때만 set
+      }
+    };
+
+    fetchLatestVote();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedVote?.voteId]); // ✅ voteId 기준으로만 작동
+
+  useEffect(() => {
     if (participantList && currentUserId) {
       const isParticipating = participantList.some((p) => String(p.id) === String(currentUserId));
       setLocalIsParticipated(isParticipating);
@@ -117,7 +143,6 @@ export default function VoteDetailModal() {
   };
 
   const handleDelete = async () => {
-
     if (!isCreator) {
       toast.warning('작성자만 삭제할 수 있습니다.');
 
@@ -135,7 +160,6 @@ export default function VoteDetailModal() {
   };
 
   const handleForceClose = async () => {
-
     if (!isCreator) {
       toast.warning('작성자만 마감할 수 있습니다.');
 

--- a/src/components/vote/detail/VoteDetailModal.tsx
+++ b/src/components/vote/detail/VoteDetailModal.tsx
@@ -56,32 +56,6 @@ export default function VoteDetailModal() {
   }, [selectedVote]);
 
   useEffect(() => {
-    let isMounted = true;
-
-    const fetchLatestVote = async () => {
-      if (!selectedVote) return;
-
-      const latestVotes = useVoteStore.getState().votes;
-      const latest = latestVotes.find((v) => v.voteId === selectedVote.voteId);
-
-      if (!latest) {
-        await updateSelectedVote(selectedVote.voteId);
-      } else if (
-        latest.description !== selectedVote.description ||
-        latest.participants !== selectedVote.participants
-      ) {
-        setSelectedVote(latest); // 변경사항이 있을 때만 set
-      }
-    };
-
-    fetchLatestVote();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [selectedVote?.voteId]); // ✅ voteId 기준으로만 작동
-
-  useEffect(() => {
     if (participantList && currentUserId) {
       const isParticipating = participantList.some((p) => String(p.id) === String(currentUserId));
       setLocalIsParticipated(isParticipating);
@@ -91,6 +65,7 @@ export default function VoteDetailModal() {
   const participationRate = Math.round((selectedVote.participants / selectedVote.recruit) * 100);
 
   const handleParticipate = async () => {
+    await fetchVotes();
     if (!selectedVote || !userInfo) return;
 
     if (isClosed) {

--- a/src/components/vote/item/VoteItem.tsx
+++ b/src/components/vote/item/VoteItem.tsx
@@ -18,9 +18,15 @@ const VoteItem: React.FC<VoteItemProps> = ({ vote }) => {
   const { requireAuth } = useRequireAuth();
 
   const handleClick = () => {
-    requireAuth(() => {
-      setSelectedVote(vote);
-      openVoteDetail(vote);
+    requireAuth(async () => {
+      await useVoteStore.getState().fetchVotes(); // ✅ 전체 투표 목록 최신화
+      const updatedVote = useVoteStore.getState().votes.find((v) => v.voteId === voteId);
+      if (updatedVote) {
+        setSelectedVote(updatedVote); // ✅ 최신 정보로 set
+        openVoteDetail(updatedVote); // ✅ 최신 정보 기반 모달 오픈
+      } else {
+        console.warn('투표 정보를 찾을 수 없습니다.');
+      }
     });
   };
 


### PR DESCRIPTION
### 🚀 작업 내용
- 모달 열릴 때 selectedVote의 voteId 기준으로 최신 데이터를 fetch하여 상태 업데이트
- vote 내용(description, 참여자 수 등)이 변경된 경우에만 setSelectedVote 호출하도록 조건 추가
- 무한 루프 방지를 위해 useEffect deps를 selectedVote?.voteId로 제한


### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->

### ✅ 체크리스트

<!-- PR을 보내기 전에 확인해야 할 사항들을 체크해주세요. -->

- [ ] 코드가 정상적으로 동작하는지 테스트했습니다.
- [ ] 스타일 가이드에 맞게 작성했습니다
